### PR TITLE
Fix site base URL using `absolute_url` filter instead of concatenation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,32 +5,32 @@
   "name": "{{site.title}}",
   "icons": [
     {
-      "src": "{{site.url}}{{site.icon-36p}}",
+      "src": "{{ '/' | absolute_url }}{{site.icon-36p}}",
       "sizes": "36x36",
       "type": "image/png"
     },
     {
-      "src": "{{site.url}}{{site.icon-48p}}",
+      "src": "{{ '/' | absolute_url }}{{site.icon-48p}}",
       "sizes": "48x48",
       "type": "image/png"
     },
     {
-      "src": "{{site.url}}{{site.icon-72p}}",
+      "src": "{{ '/' | absolute_url }}{{site.icon-72p}}",
       "sizes": "72x72",
       "type": "image/png"
     },
     {
-      "src": "{{site.url}}{{site.icon-96p}}",
+      "src": "{{ '/' | absolute_url }}{{site.icon-96p}}",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "{{site.url}}{{site.icon-144p}}",
+      "src": "{{ '/' | absolute_url }}{{site.icon-144p}}",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "{{site.url}}{{site.icon-192p}}",
+      "src": "{{ '/' | absolute_url }}{{site.icon-192p}}",
       "sizes": "192x192",
       "type": "image/png"
     }


### PR DESCRIPTION
Note: The `site.icon-*` config attributes are not present

Fixes le4ker/personal-jekyll-theme#276

See more: https://jekyllrb.com/docs/liquid/filters/
